### PR TITLE
feat(wechat-pc): 按实测勘测修订 4.x/3.x 路径布局

### DIFF
--- a/crates/scaffold/tests/wechat_pc_safety.rs
+++ b/crates/scaffold/tests/wechat_pc_safety.rs
@@ -142,10 +142,22 @@ fn wechat_pc_globs_are_safe() {
     // 4.x 图片/视频共用 msg/video/ 树，按后缀分流。两个桶必须互斥——
     // 不允许 .mp4 同时落到 received-images，也不允许 .jpg 落到 received-videos。
     let cross_bucket: &[(&str, &str)] = &[
-        ("received-images", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc.mp4"),
-        ("received-images", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc_raw.mp4"),
-        ("received-videos", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc.jpg"),
-        ("received-videos", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc_thumb.jpg"),
+        (
+            "received-images",
+            "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc.mp4",
+        ),
+        (
+            "received-images",
+            "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc_raw.mp4",
+        ),
+        (
+            "received-videos",
+            "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc.jpg",
+        ),
+        (
+            "received-videos",
+            "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc_thumb.jpg",
+        ),
     ];
     for (forbidden_id, p) in cross_bucket {
         let hits = matching_scopes(&scopes, p);

--- a/crates/scaffold/tests/wechat_pc_safety.rs
+++ b/crates/scaffold/tests/wechat_pc_safety.rs
@@ -95,17 +95,28 @@ fn wechat_pc_globs_are_safe() {
         ("avatar-cache", "C:/Users/test/Documents/xwechat_files/all_users/head_imgs/aa/foo"),
         ("apm-records", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/apm_record/process_duration/x"),
         ("received-files", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/file/2026-05/note.pdf"),
-        ("received-videos", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/clip.mp4"),
-        ("received-images", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/image/2026-05/photo.jpg"),
+        // 4.x 实测：image/video 共用 msg/video/<YYYY-MM>/ 目录，按后缀分流。
+        // 真实命名包含 `<hash>.mp4`（视频）、`<hash>_raw.mp4`（高清版）、
+        // `<hash>.jpg`（图片）、`<hash>_thumb.jpg`（视频缩略图）。
+        ("received-videos", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc123.mp4"),
+        ("received-videos", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc123_raw.mp4"),
+        ("received-images", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/photo123.jpg"),
+        ("received-images", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc123_thumb.jpg"),
+        ("received-images", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/sticker.png"),
         ("voice-attachments", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/attach/abc/voice.amr"),
         ("chat-backups", "C:/Users/test/Documents/xwechat_files/Backup/wxid_aaa/data.bak"),
         ("app-logs-crashes", "C:/Users/test/AppData/Roaming/Tencent/xwechat/log/player/x.log"),
         ("app-logs-crashes", "C:/Users/test/AppData/Roaming/Tencent/xwechat/crashinfo/reports/x.dmp"),
         ("app-update-leftover", "C:/Users/test/AppData/Roaming/Tencent/xwechat/update/download/x.exe"),
         ("app-update-leftover", "C:/Users/test/AppData/Roaming/Tencent/xwechat/confsdk/x.cfg"),
+        // 3.x 两套并存路径：path_one 顶层（Image/Image, Video, Files, Attachment）
+        // + path_two FileStorage/* —— 都要被对应 scope 命中。
         ("image-cache-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/FileStorage/Image/2026-05/img.dat"),
+        ("image-cache-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/Image/Image/2026-05/img.dat"),
         ("video-cache-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/FileStorage/Video/clip.mp4"),
+        ("video-cache-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/Video/2026-05/clip.mp4"),
         ("file-cache-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/FileStorage/File/note.pdf"),
+        ("file-cache-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/Files/2026-05/note.pdf"),
         ("voice-cache-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/FileStorage/Voice2/2026-05/v.amr"),
         ("voice-cache-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/FileStorage/Voice/old.amr"),
         ("msg-attach-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/FileStorage/MsgAttach/abc/Image/Thumb_x.dat"),
@@ -113,6 +124,7 @@ fn wechat_pc_globs_are_safe() {
         ("sticker-cache-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/FileStorage/Emotion/x.gif"),
         ("temp-files-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/FileStorage/Temp/dl_part.tmp"),
         ("cache-misc-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/FileStorage/Cache/x"),
+        ("cache-misc-3x", "C:/Users/test/Documents/WeChat Files/wxid_legacy/Attachment/2026-05/thumb.dat"),
         ("app-logs-crashes-3x", "C:/Users/test/AppData/Roaming/Tencent/WeChat/Log/2026/x.log"),
         ("app-logs-crashes-3x", "C:/Users/test/AppData/Roaming/Tencent/WeChat/Logs/x.log"),
         ("app-logs-crashes-3x", "C:/Users/test/AppData/Roaming/Tencent/WeChat/CrashReport/x.dmp"),
@@ -124,6 +136,22 @@ fn wechat_pc_globs_are_safe() {
         assert!(
             hits.contains(expected_id),
             "expected scope `{expected_id}` to match `{p}`, but matched {hits:?}",
+        );
+    }
+
+    // 4.x 图片/视频共用 msg/video/ 树，按后缀分流。两个桶必须互斥——
+    // 不允许 .mp4 同时落到 received-images，也不允许 .jpg 落到 received-videos。
+    let cross_bucket: &[(&str, &str)] = &[
+        ("received-images", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc.mp4"),
+        ("received-images", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc_raw.mp4"),
+        ("received-videos", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc.jpg"),
+        ("received-videos", "C:/Users/test/Documents/xwechat_files/wxid_aaa_bbb/msg/video/2026-05/abc_thumb.jpg"),
+    ];
+    for (forbidden_id, p) in cross_bucket {
+        let hits = matching_scopes(&scopes, p);
+        assert!(
+            !hits.contains(forbidden_id),
+            "scope `{forbidden_id}` must NOT match `{p}` (cross-bucket leak); got {hits:?}",
         );
     }
 

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -139,7 +139,11 @@ where
                     });
                 })
             }))
-            .unwrap_or_else(|_| Err(anyhow::anyhow!("MFT scan panicked (likely non-NTFS volume)")));
+            .unwrap_or_else(|_| {
+                Err(anyhow::anyhow!(
+                    "MFT scan panicked (likely non-NTFS volume)"
+                ))
+            });
             match mft_result {
                 Ok(n) => {
                     stats.mft_ms = mft_t0.elapsed().as_millis() as u64;

--- a/docs/scaffold-requirements/messaging.md
+++ b/docs/scaffold-requirements/messaging.md
@@ -124,7 +124,7 @@ xwechat_files/
     │   ├── attach/<chat-hash>/          L2 语音/附件
     │   ├── file/<YYYY-MM>/              L2 接收文件
     │   ├── migrate/                     keep
-    │   └── video/<YYYY-MM>/             L2 视频
+    │   └── video/<YYYY-MM>/             L2 视频 + 图片混存（见 7.5）
     ├── resource/                        keep（一般空）
     └── temp/                            L1 临时（含 ImageTemp / InputTemp / head_image / session-id 子目录）
 ```
@@ -165,10 +165,55 @@ update/           L1（download/ + patch/，更新落地后可清）
 | `avatar-cache` | 头像缓存 | `**/xwechat_files/all_users/head_imgs/**` | recycle | none |
 | `apm-records` | APM 遥测 | `**/xwechat_files/wxid_*/apm_record/**` | recycle | none |
 | `received-files` | 接收的文件 | `**/xwechat_files/wxid_*/msg/file/**` | recycle | days=30 |
-| `received-videos` | 接收的视频 | `**/xwechat_files/wxid_*/msg/video/**` | recycle | days=7 |
+| `received-videos` | 接收的视频 | `**/xwechat_files/wxid_*/msg/video/**/*.{mp4,mov,m4v,3gp,mkv,webm,avi,m4s}` | recycle | days=7 |
+| `received-images` | 接收的图片 | `**/xwechat_files/wxid_*/msg/video/**/*.{jpg,jpeg,png,gif,webp,bmp,heic,heif}` | recycle | days=30 |
 | `voice-attachments` | 语音/消息附件 | `**/xwechat_files/wxid_*/msg/attach/**` | recycle | days=30 |
 | `chat-backups` | 聊天备份 | `**/xwechat_files/Backup/**` | recycle | confirm=false |
 | `app-logs-crashes` | 应用日志/崩溃报告 | `%APPDATA%/Tencent/xwechat/{log,crashinfo}/**` | recycle | none |
 | `app-update-leftover` | 安装包/远程配置缓存 | `%APPDATA%/Tencent/xwechat/{update,confsdk}/**` | recycle | none |
 
 3.x 兼容 scope 4 个（图片/视频/文件/Cache）作为 legacy 同时保留，glob 用 `**/WeChat Files/wxid_*/FileStorage/{Image,Video,File,Cache}/**` 形态。
+
+### 7.5 实测附录：4.x 图片/视频共用 video/ 目录
+
+**勘测发现（2026-05）**：4.x 实际不存在 `msg/image/` 子目录。用户接收的图片和视频都堆在 `msg/video/<YYYY-MM>/` 下，按文件名后缀区分：
+
+```
+msg/video/2026-05/
+├── <hash>.jpg               图片原文件
+├── <hash>_thumb.jpg         视频缩略图（_thumb 后缀）
+├── <hash>.mp4               视频
+└── <hash>_raw.mp4           高清版视频（_raw 后缀）
+```
+
+**对 7.4 蓝图的修订**：原蓝图 `received-videos` 用 `msg/video/**` 会同时命中图片，`received-images` 当时给的 `msg/image/**` 在 4.x 是死路径。最终落到 wechat-pc.toml 的两个 scope 共用 `msg/video/**` 树，按 brace 后缀分流——简单一致，缩略图按后缀归图片桶，高清版按后缀归视频桶。
+
+**为什么不"_thumb.jpg 跟着主视频走"**：这要么靠正则要么靠后端配对，把声明式 schema 复杂度推高一档；用户两个桶一起清就完美，单清一边留下的孤儿缩略图 WeChat 重生即可。符合 80% 哲学（简单解决 80% 场景，砍长尾）。
+
+**safety test 覆盖**：`crates/scaffold/tests/wechat_pc_safety.rs` 已加 `_thumb.jpg`/`_raw.mp4` 正向断言 + 桶不交叉反向断言（mp4 不落 received-images，jpg 不落 received-videos）。
+
+### 7.6 实测附录：3.x 顶层目录与 FileStorage 双布局并存
+
+**信息来源（2026-05）**：`CleanMyWeChat` 项目 `get_fileNum` 函数显示，3.x 时代用户数据有两套并存的目录布局——早期用 `<wxid>/` 顶层目录，后期统一搬进 `<wxid>/FileStorage/`。CleanMyWeChat 的每个清理桶都同时扫两套：
+
+| 类别（CleanMyWeChat 概念） | path_one（顶层老布局） | path_two（FileStorage 新布局） |
+|----|----|----|
+| 图片缩略图缓存（picCache） | `<wxid>/Attachment/` | `<wxid>/FileStorage/Cache/` |
+| 接收文件（file） | `<wxid>/Files/` | `<wxid>/FileStorage/File/` |
+| 接收图片（pic） | `<wxid>/Image/Image/` | `<wxid>/FileStorage/Image/` |
+| 接收视频（video） | `<wxid>/Video/` | `<wxid>/FileStorage/Video/` |
+
+**对 7.4/3.x legacy 蓝图的修订**：原蓝图只覆盖 path_two（FileStorage/*）。落到 wechat-pc.toml 的 4 个 3.x scope 用 brace 把双路径合并到同一 glob：
+
+| scope id | glob |
+|----|----|
+| `image-cache-3x` | `**/WeChat Files/wxid_*/{Image/Image,FileStorage/Image}/**` |
+| `video-cache-3x` | `**/WeChat Files/wxid_*/{Video,FileStorage/Video}/**` |
+| `file-cache-3x` | `**/WeChat Files/wxid_*/{Files,FileStorage/File}/**` |
+| `cache-misc-3x` | `**/WeChat Files/wxid_*/{Attachment,FileStorage/Cache}/**` |
+
+`Attachment/` 按 CleanMyWeChat 的 picCache 语义并入 `cache-misc-3x`（与 `FileStorage/Cache/` 等价），不单开 scope——3.x 装机量正在萎缩，UI 卡片不必再多一张。
+
+`voice-cache-3x` / `sticker-cache-3x` / `temp-files-3x` / `msg-attach-3x` 维持只扫 FileStorage/*，CleanMyWeChat 没揭示这几类有 path_one。
+
+**safety test 覆盖**：每个改动 scope 都新增了一条 path_one 风格的正向命中（`Image/Image/2026-05/img.dat`、`Video/2026-05/clip.mp4`、`Files/2026-05/note.pdf`、`Attachment/2026-05/thumb.dat`）；红线断言不变（Msg/MultiMsg/config/Accounts/Favorites/FileStorage/CustomEmotion 仍 zero match）。

--- a/scaffolds/wechat-pc.toml
+++ b/scaffolds/wechat-pc.toml
@@ -94,10 +94,13 @@ category = "media"
 variant  = "4.x"
 prompt   = { kind = "days", default = 30, label = "保留最近多少天" }
 
+# 4.x 实测：图片和视频混在同一棵 msg/video/<YYYY-MM>/ 目录下（msg/image/
+# 在 4.x 不存在）。两个 scope 共享 video/ 树，按文件后缀分流；缩略图
+# (_thumb.jpg) 归图片桶，高清版 (_raw.mp4) 归视频桶——纯按后缀，简单一致。
 [[scope]]
 id       = "received-videos"
 label    = "接收的视频"
-glob     = "**/xwechat_files/wxid_*/msg/video/**"
+glob     = "**/xwechat_files/wxid_*/msg/video/**/*.{mp4,mov,m4v,3gp,mkv,webm,avi,m4s}"
 mode     = "recycle"
 category = "media"
 variant  = "4.x"
@@ -106,7 +109,7 @@ prompt   = { kind = "days", default = 7, label = "保留最近多少天" }
 [[scope]]
 id       = "received-images"
 label    = "接收的图片"
-glob     = "**/xwechat_files/wxid_*/msg/image/**"
+glob     = "**/xwechat_files/wxid_*/msg/video/**/*.{jpg,jpeg,png,gif,webp,bmp,heic,heif}"
 mode     = "recycle"
 category = "media"
 variant  = "4.x"
@@ -160,10 +163,13 @@ prompt   = { kind = "none" }
 # Msg / MultiMsg 是聊天 DB，硬红线，不在任何 scope 内。
 # ============================================================================
 
+# 3.x 双路径：早期版本用顶层目录（Image/Image, Video, Files, Attachment），
+# 后期统一搬进 FileStorage/{Image,Video,File,Cache}。两套都得扫——参见
+# CleanMyWeChat 的 picCache/file/pic/video 分支：每个桶都同时匹配两种写法。
 [[scope]]
 id       = "image-cache-3x"
 label    = "接收的图片"
-glob     = "**/WeChat Files/wxid_*/FileStorage/Image/**"
+glob     = "**/WeChat Files/wxid_*/{Image/Image,FileStorage/Image}/**"
 mode     = "recycle"
 category = "media"
 variant  = "3.x"
@@ -172,7 +178,7 @@ prompt   = { kind = "days", default = 30, label = "保留最近多少天" }
 [[scope]]
 id       = "video-cache-3x"
 label    = "接收的视频"
-glob     = "**/WeChat Files/wxid_*/FileStorage/Video/**"
+glob     = "**/WeChat Files/wxid_*/{Video,FileStorage/Video}/**"
 mode     = "recycle"
 category = "media"
 variant  = "3.x"
@@ -181,7 +187,7 @@ prompt   = { kind = "days", default = 7, label = "保留最近多少天" }
 [[scope]]
 id       = "file-cache-3x"
 label    = "接收的文件"
-glob     = "**/WeChat Files/wxid_*/FileStorage/File/**"
+glob     = "**/WeChat Files/wxid_*/{Files,FileStorage/File}/**"
 mode     = "recycle"
 category = "media"
 variant  = "3.x"
@@ -226,7 +232,9 @@ prompt   = { kind = "none" }
 [[scope]]
 id       = "cache-misc-3x"
 label    = "杂项缓存"
-glob     = "**/WeChat Files/wxid_*/FileStorage/Cache/**"
+# Attachment/ 是顶层版本的图片/缩略图缓存，FileStorage/Cache/ 是统一布局后的等价物，
+# CleanMyWeChat 的 picCacheCheck 分支同时清两者。
+glob     = "**/WeChat Files/wxid_*/{Attachment,FileStorage/Cache}/**"
 mode     = "recycle"
 category = "cache"
 variant  = "3.x"


### PR DESCRIPTION
## Summary

- **4.x**: image/video 共用 `msg/video/<YYYY-MM>/` 目录（`msg/image/` 在 4.x 不存在），两个 scope 按文件后缀分流——视频桶吃 `.mp4/.mov/_raw.mp4` 等，图片桶吃 `.jpg/.png/_thumb.jpg` 等
- **3.x**: 顶层目录与 `FileStorage/` 双布局并存（CleanMyWeChat 的 `get_fileNum` 揭示），4 个 3.x scope 用 brace glob 把两套合并；`Attachment/` 按 picCache 语义并入 `cache-misc-3x`，不单开 scope（3.x 装机量在萎缩，UI 不加新卡）
- safety test 加 `_raw.mp4`/`_thumb.jpg`/`.png` 正向断言 + cross-bucket 反向断言（mp4 不能落 received-images，jpg 不能落 received-videos）；红线断言保持 zero match
- `docs/scaffold-requirements/messaging.md` 加 §7.5（4.x 共用 video/）+ §7.6（3.x 双布局）实测附录

## Type

- [x] Bug fix（旧 glob `msg/image/**` 在 4.x 路径不存在，导致接收图片永远 zero match——sliently broken）

## New scaffold checklist

修订已有 scaffold，不是新增；勾选相关项：

- [x] **Phase 0**: 已读 `crates/scaffold/src/lib.rs`、`Studio.tsx`、`types.ts`，确认改 glob 不需要动 UI
- [x] **Phase 5-7**: `messaging.md` §7.5 / §7.6 实测附录已写
- [x] **Phase 9**: `cargo run -p pinkbin-scaffold-lint -- scaffolds/wechat-pc.toml` → ok
- [x] **Phase 10**: `cargo test -p pinkbin-scaffold --test wechat_pc_safety` → 2 passed; 含红线断言 + 新增 cross-bucket 断言
- [x] **Phase 12**: `pnpm tauri dev` 手测微信卡片大小（4.x 接收图片/视频按后缀分流；3.x 顶层 + FileStorage 双路径都进对应 scope）
- [n/a] **Phase 11**: 未改 `Scaffold`/`Scope` 结构，无需 tsc check
- [n/a] **Phase 14**: STATUS.md 不变（不是新增 scaffold）

## Test plan

- [x] `cargo test -p pinkbin-scaffold --test wechat_pc_safety` — 2 passed; 0 failed
- [x] `cargo run -p pinkbin-scaffold-lint -- scaffolds/wechat-pc.toml` — ok
- [x] `pnpm tauri dev` smoke-tested locally