### PR TITLE
fix: 弹窗拖拽选词超出范围误触发关闭

### DIFF
--- a/apps/desktop/src/components/CleanupModal.tsx
+++ b/apps/desktop/src/components/CleanupModal.tsx
@@ -544,8 +544,8 @@ export function CleanupModal({ scaffold: sc, matches, onClose, onCleaned }: Prop
   }, [isConda, matches, scopeSizes]);
 
   return (
-    <div className="modal-bg" onClick={onClose}>
-      <div className="modal cleanup-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-bg" onPointerDown={onClose}>
+      <div className="modal cleanup-modal" onPointerDown={(e) => e.stopPropagation()}>
         <div className="modal-head">
           <div>
             清理 · {sc.name}

--- a/apps/desktop/src/components/Settings.tsx
+++ b/apps/desktop/src/components/Settings.tsx
@@ -71,8 +71,8 @@ export function Settings({ onClose }: Props) {
   };
 
   return (
-    <div className="modal-bg" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-bg" onPointerDown={onClose}>
+      <div className="modal" onPointerDown={(e) => e.stopPropagation()}>
         <div className="modal-head">
           <div>AI 顾问设置 {saved && <CheckCircle2 size={16} style={{ verticalAlign: 'middle', marginLeft: 6, color: 'var(--pink-deep)' }} />}</div>
           <button className="ghost icon" onClick={onClose}><X size={16} /></button>


### PR DESCRIPTION
把 modal-bg 的 onClick
   改为 onPointerDown，防止用户在输入框拖拽选词时鼠标松开在弹窗外导致意外关闭。同时也修复了 CleanupModal 中的同样问题。