### PR TITLE
fix(desktop): AI 文本对话改由后端请求

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -414,7 +424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -427,7 +437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1557,9 +1567,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4089,6 +4101,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4109,7 +4142,7 @@ checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -5463,7 +5496,7 @@ dependencies = [
  "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
- "windows-strings",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -5544,6 +5577,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5562,12 +5606,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ ntfs               = "0.4"
 windows-sys        = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Registry"] }
 globset            = "0.4"
 trash              = "5"
-reqwest            = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest            = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "system-proxy"] }
 tokio              = { version = "1", features = ["full"] }
 once_cell          = "1"
 chrono             = { version = "0.4", features = ["serde"] }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,7 +4,9 @@ use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
 use include_dir::{include_dir, Dir};
-use pinkbin_advisor::{advise as advise_provider, AdvisorRequest, AdvisorResponse, Provider};
+use pinkbin_advisor::{
+    advise as advise_provider, chat as chat_provider, AdvisorRequest, AdvisorResponse, Provider,
+};
 use pinkbin_executor::{execute, Plan, UndoEntry};
 use pinkbin_scaffold::{
     compile_all, detect_compiled, detect_for, expand_env, load_dir, parse_toml, CompiledScaffold,
@@ -852,6 +854,23 @@ async fn advise(
 }
 
 #[tauri::command]
+async fn advisor_chat(
+    state: State<'_, AppState>,
+    system: String,
+    user: String,
+) -> Result<String, String> {
+    let provider = state
+        .advisor
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| "advisor not configured — open Settings".to_string())?;
+    chat_provider(&provider, &system, &user)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 fn inspect_path(path: String, sample_count: usize) -> Vec<String> {
     sample_paths(&path, sample_count)
 }
@@ -1332,6 +1351,7 @@ pub fn run() {
             execute_scope,
             list_conda_envs,
             advise,
+            advisor_chat,
             inspect_path,
             reveal_in_explorer,
             execute_plan,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -13,7 +13,7 @@ import { Splitter } from './components/Splitter';
 import { Logo } from './components/Logo';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { formatBytes } from './format';
-import { loadSettings, isConfigured } from './advisorClient';
+import { loadSettings, isConfigured, syncAdvisorToBackend } from './advisorClient';
 
 function isDriveRoot(p: string): boolean {
   // C: / C:\ / C:/  — anything beyond is a subfolder
@@ -73,7 +73,10 @@ export default function App() {
     const s = loadSettings();
     setAdvisorTag(isConfigured(s) ? { provider: s.provider } : null);
   };
-  useEffect(() => { refreshAdvisorTag(); }, []);
+  useEffect(() => {
+    refreshAdvisorTag();
+    syncAdvisorToBackend().catch(() => {});
+  }, []);
   const [leftWidth, setLeftWidth] = useState<number>(() => {
     const v = Number(localStorage.getItem('pinkbin.leftWidth'));
     return Number.isFinite(v) && v > MIN_LEFT ? v : DEFAULT_LEFT;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -75,6 +75,8 @@ export default function App() {
   };
   useEffect(() => {
     refreshAdvisorTag();
+    // Settings live in localStorage; after a restart, hydrate Rust state so
+    // backend advisor commands work before the user reopens Settings.
     syncAdvisorToBackend().catch(() => {});
   }, []);
   const [leftWidth, setLeftWidth] = useState<number>(() => {

--- a/apps/desktop/src/advisorClient.ts
+++ b/apps/desktop/src/advisorClient.ts
@@ -241,6 +241,8 @@ async function runChatRaw(system: string, user: string, images?: ChatImage[]): P
   const imgs = images ?? [];
 
   if (isTauri && imgs.length === 0) {
+    // Backend requests bypass browser CORS preflight; keep image chat on the
+    // browser path because provider-specific vision payloads already work here.
     await syncAdvisorToBackend(settings);
     return invoke<string>('advisor_chat', { system, user: fullUser });
   }

--- a/apps/desktop/src/advisorClient.ts
+++ b/apps/desktop/src/advisorClient.ts
@@ -1,9 +1,12 @@
-// Browser-side AI advisor client — talks to OpenAI / Anthropic / Ollama directly
-// from the browser, so the preview mode can give real answers.
+// AI advisor client. Browser preview talks to providers directly. In the
+// packaged Tauri app, text-only chat goes through the backend so compatible
+// OpenAI relays do not need browser CORS support.
 //
 // Settings persist to localStorage under "pinkbin.advisor".
 
+import { invoke } from '@tauri-apps/api/core';
 import type { AdvisorRequest, AdvisorResponse } from './types';
+import { isTauri } from './env';
 
 export type Provider = 'openai' | 'anthropic' | 'gemini' | 'ollama';
 
@@ -179,6 +182,16 @@ export function isConfigured(s: AdvisorSettings | null): s is AdvisorSettings {
   return Boolean(s.apiKey && s.model);
 }
 
+export async function syncAdvisorToBackend(settings = loadSettings()): Promise<void> {
+  if (!isTauri || !isConfigured(settings)) return;
+  await invoke<void>('set_advisor', {
+    provider: settings.provider,
+    apiKey: settings.provider === 'ollama' ? null : settings.apiKey,
+    model: settings.model,
+    baseUrl: settings.baseUrl || null,
+  });
+}
+
 const CHAT_SYSTEM = `You are Pinkbin's AI advisor — a friendly assistant that helps users figure out what their disk folders are and whether to delete them. Use the metadata you are given (the user's question references a folder by its path, size, samples). Be concise (2-4 sentences), in the user's language. If you suggest deleting, say what to delete (the whole folder vs a sub-scope) and via what mechanism (回收站 / 手动整理 / 卸载应用). Never recommend rm -rf on system paths.`;
 
 const OVERVIEW_SYSTEM = `You are Pinkbin's AI advisor. The user just finished scanning their disk. You receive a JSON summary of the largest folders. Write a friendly Chinese overview (~180-220 字) covering, in order, with empty lines between sections:
@@ -226,6 +239,11 @@ async function runChatRaw(system: string, user: string, images?: ChatImage[]): P
   }
   const fullUser = user;
   const imgs = images ?? [];
+
+  if (isTauri && imgs.length === 0) {
+    await syncAdvisorToBackend(settings);
+    return invoke<string>('advisor_chat', { system, user: fullUser });
+  }
 
   if (settings.provider === 'openai') {
     const url = (settings.baseUrl || 'https://api.openai.com/v1').replace(/\/$/, '');

--- a/crates/advisor/src/lib.rs
+++ b/crates/advisor/src/lib.rs
@@ -78,10 +78,40 @@ Rules:
 - Do not include any prose outside the JSON object."#;
 
 pub async fn advise(provider: &Provider, req: &AdvisorRequest) -> anyhow::Result<AdvisorResponse> {
+    let user_prompt = serde_json::to_string_pretty(req)?;
+    let raw = complete_text(provider, SYSTEM, &user_prompt, ResponseMode::Json).await?;
+
+    let parsed: AdvisorResponse =
+        serde_json::from_str(&raw).or_else(|_| serde_json::from_str(strip_codefence(&raw)))?;
+    Ok(parsed)
+}
+
+pub async fn chat(provider: &Provider, system: &str, user: &str) -> anyhow::Result<String> {
+    let text = complete_text(provider, system, user, ResponseMode::Plain)
+        .await?
+        .trim()
+        .to_string();
+    if text.is_empty() {
+        anyhow::bail!("empty response from advisor chat");
+    }
+    Ok(text)
+}
+
+#[derive(Clone, Copy)]
+enum ResponseMode {
+    Json,
+    Plain,
+}
+
+async fn complete_text(
+    provider: &Provider,
+    system: &str,
+    user_prompt: &str,
+    mode: ResponseMode,
+) -> anyhow::Result<String> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(60))
         .build()?;
-    let user_prompt = serde_json::to_string_pretty(req)?;
 
     let raw = match provider {
         Provider::OpenAI {
@@ -89,14 +119,16 @@ pub async fn advise(provider: &Provider, req: &AdvisorRequest) -> anyhow::Result
             model,
             base_url,
         } => {
-            let body = serde_json::json!({
+            let mut body = serde_json::json!({
                 "model": model,
-                "response_format": { "type": "json_object" },
                 "messages": [
-                    { "role": "system", "content": SYSTEM },
+                    { "role": "system", "content": system },
                     { "role": "user",   "content": user_prompt }
                 ]
             });
+            if matches!(mode, ResponseMode::Json) {
+                body["response_format"] = serde_json::json!({ "type": "json_object" });
+            }
             let r = client
                 .post(format!(
                     "{}/chat/completions",
@@ -108,10 +140,7 @@ pub async fn advise(provider: &Provider, req: &AdvisorRequest) -> anyhow::Result
                 .await?
                 .error_for_status()?;
             let v: serde_json::Value = r.json().await?;
-            v["choices"][0]["message"]["content"]
-                .as_str()
-                .ok_or_else(|| anyhow::anyhow!("openai: missing message.content"))?
-                .to_string()
+            extract_openai_text(&v)?.to_string()
         }
         Provider::Anthropic {
             api_key,
@@ -120,8 +149,8 @@ pub async fn advise(provider: &Provider, req: &AdvisorRequest) -> anyhow::Result
         } => {
             let body = serde_json::json!({
                 "model": model,
-                "max_tokens": 2048,
-                "system": SYSTEM,
+                "max_tokens": if matches!(mode, ResponseMode::Json) { 2048 } else { 4096 },
+                "system": system,
                 "messages": [{ "role": "user", "content": user_prompt }]
             });
             let r = client
@@ -133,42 +162,24 @@ pub async fn advise(provider: &Provider, req: &AdvisorRequest) -> anyhow::Result
                 .await?
                 .error_for_status()?;
             let v: serde_json::Value = r.json().await?;
-            // extended-thinking 模型先返 {type:"thinking",...} 再返 {type:"text",...},
-            // 不能假设 content[0] 是 text；遍历 content 数组拼所有 text block。
-            let text = v["content"]
-                .as_array()
-                .map(|blocks| {
-                    blocks
-                        .iter()
-                        .filter(|b| b["type"] == "text")
-                        .filter_map(|b| b["text"].as_str())
-                        .collect::<Vec<_>>()
-                        .join("")
-                })
-                .unwrap_or_default();
-            if text.trim().is_empty() {
-                let stop = v["stop_reason"].as_str().unwrap_or("unknown");
-                if stop == "max_tokens" {
-                    anyhow::bail!(
-                        "anthropic: 没拿到 text block (stop_reason=max_tokens) — 模型在 thinking 阶段被截断, 把 max_tokens 调大重试"
-                    );
-                }
-                anyhow::bail!("anthropic: 没拿到 text block (stop_reason={stop})");
-            }
-            text
+            extract_anthropic_text(&v)?
         }
         Provider::Gemini {
             api_key,
             model,
             base_url,
         } => {
-            let body = serde_json::json!({
-                "systemInstruction": { "parts": [{ "text": SYSTEM }] },
-                "contents": [{ "role": "user", "parts": [{ "text": user_prompt }] }],
-                "generationConfig": {
+            let generation_config = match mode {
+                ResponseMode::Json => serde_json::json!({
                     "responseMimeType": "application/json",
                     "temperature": 0.2
-                }
+                }),
+                ResponseMode::Plain => serde_json::json!({ "temperature": 0.4 }),
+            };
+            let body = serde_json::json!({
+                "systemInstruction": { "parts": [{ "text": system }] },
+                "contents": [{ "role": "user", "parts": [{ "text": user_prompt }] }],
+                "generationConfig": generation_config
             });
             let url = format!(
                 "{}/v1beta/models/{}:generateContent?key={}",
@@ -183,23 +194,20 @@ pub async fn advise(provider: &Provider, req: &AdvisorRequest) -> anyhow::Result
                 .await?
                 .error_for_status()?;
             let v: serde_json::Value = r.json().await?;
-            v["candidates"][0]["content"]["parts"][0]["text"]
-                .as_str()
-                .ok_or_else(|| {
-                    anyhow::anyhow!("gemini: missing candidates[0].content.parts[0].text")
-                })?
-                .to_string()
+            extract_gemini_text(&v)?.to_string()
         }
         Provider::Ollama { base_url, model } => {
-            let body = serde_json::json!({
+            let mut body = serde_json::json!({
                 "model": model,
-                "format": "json",
                 "stream": false,
                 "messages": [
-                    { "role": "system", "content": SYSTEM },
+                    { "role": "system", "content": system },
                     { "role": "user",   "content": user_prompt }
                 ]
             });
+            if matches!(mode, ResponseMode::Json) {
+                body["format"] = serde_json::json!("json");
+            }
             let r = client
                 .post(format!("{}/api/chat", base_url.trim_end_matches('/')))
                 .json(&body)
@@ -207,16 +215,54 @@ pub async fn advise(provider: &Provider, req: &AdvisorRequest) -> anyhow::Result
                 .await?
                 .error_for_status()?;
             let v: serde_json::Value = r.json().await?;
-            v["message"]["content"]
-                .as_str()
-                .ok_or_else(|| anyhow::anyhow!("ollama: missing message.content"))?
-                .to_string()
+            extract_ollama_text(&v)?.to_string()
         }
     };
+    Ok(raw)
+}
 
-    let parsed: AdvisorResponse =
-        serde_json::from_str(&raw).or_else(|_| serde_json::from_str(strip_codefence(&raw)))?;
-    Ok(parsed)
+fn extract_openai_text(v: &serde_json::Value) -> anyhow::Result<&str> {
+    v["choices"][0]["message"]["content"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("openai: missing message.content"))
+}
+
+fn extract_anthropic_text(v: &serde_json::Value) -> anyhow::Result<String> {
+    // extended-thinking 模型先返 {type:"thinking",...} 再返 {type:"text",...},
+    // 不能假设 content[0] 是 text；遍历 content 数组拼所有 text block。
+    let text = v["content"]
+        .as_array()
+        .map(|blocks| {
+            blocks
+                .iter()
+                .filter(|b| b["type"] == "text")
+                .filter_map(|b| b["text"].as_str())
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default();
+    if text.trim().is_empty() {
+        let stop = v["stop_reason"].as_str().unwrap_or("unknown");
+        if stop == "max_tokens" {
+            anyhow::bail!(
+                "anthropic: 没拿到 text block (stop_reason=max_tokens) — 模型在 thinking 阶段被截断, 把 max_tokens 调大重试"
+            );
+        }
+        anyhow::bail!("anthropic: 没拿到 text block (stop_reason={stop})");
+    }
+    Ok(text)
+}
+
+fn extract_gemini_text(v: &serde_json::Value) -> anyhow::Result<&str> {
+    v["candidates"][0]["content"]["parts"][0]["text"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("gemini: missing candidates[0].content.parts[0].text"))
+}
+
+fn extract_ollama_text(v: &serde_json::Value) -> anyhow::Result<&str> {
+    v["message"]["content"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("ollama: missing message.content"))
 }
 
 fn strip_codefence(s: &str) -> &str {
@@ -224,4 +270,53 @@ fn strip_codefence(s: &str) -> &str {
     let s = s.strip_prefix("```json").unwrap_or(s);
     let s = s.strip_prefix("```").unwrap_or(s);
     s.strip_suffix("```").unwrap_or(s).trim()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_json_code_fence() {
+        assert_eq!(
+            strip_codefence("```json\n{\"ok\":true}\n```"),
+            "{\"ok\":true}"
+        );
+        assert_eq!(strip_codefence("```\nhello\n```"), "hello");
+    }
+
+    #[test]
+    fn extracts_text_from_provider_shapes() {
+        let openai = serde_json::json!({
+            "choices": [{ "message": { "content": "openai text" } }]
+        });
+        assert_eq!(extract_openai_text(&openai).unwrap(), "openai text");
+
+        let anthropic = serde_json::json!({
+            "content": [
+                { "type": "thinking", "thinking": "hidden" },
+                { "type": "text", "text": "hello " },
+                { "type": "text", "text": "world" }
+            ]
+        });
+        assert_eq!(extract_anthropic_text(&anthropic).unwrap(), "hello world");
+
+        let gemini = serde_json::json!({
+            "candidates": [{ "content": { "parts": [{ "text": "gemini text" }] } }]
+        });
+        assert_eq!(extract_gemini_text(&gemini).unwrap(), "gemini text");
+
+        let ollama = serde_json::json!({ "message": { "content": "ollama text" } });
+        assert_eq!(extract_ollama_text(&ollama).unwrap(), "ollama text");
+    }
+
+    #[test]
+    fn anthropic_empty_text_reports_stop_reason() {
+        let value = serde_json::json!({
+            "stop_reason": "max_tokens",
+            "content": [{ "type": "thinking", "thinking": "..." }]
+        });
+        let err = extract_anthropic_text(&value).unwrap_err().to_string();
+        assert!(err.contains("stop_reason=max_tokens"));
+    }
 }


### PR DESCRIPTION
## Summary

- 桌面端无图片 AI 对话/概览改由 Tauri 后端发送请求，避免 WebView `fetch` 被 OpenAI 兼容接口的 CORS preflight 阻断。
- `pinkbin-advisor` 新增纯文本 `chat` 入口，并复用现有 provider 请求/解析逻辑；原 `advise` 仍保持 JSON 模式。
- 启动时同步本地保存的 AI 配置到后端，避免 UI 显示已配置但后端状态为空。
- 为 `reqwest` 启用 `system-proxy`，保证后端请求仍可继承系统代理。

## Scope

本 PR 只影响桌面端 text-only advisor chat：

- 影响：扫描概览、普通文本问答。
- 不影响：图片对话，仍走原前端路径。
- 不影响：浏览器 preview，仍走原前端直连逻辑。
- 不影响：扫描、清理、删除、回收站、scaffold 规则。

## Why

部分 OpenAI 兼容接口可以正常处理服务端请求，但不会正确响应浏览器 CORS preflight。  
桌面版运行在 Tauri 环境中，已有 Rust 后端和 provider 配置状态，因此 text-only AI 请求改由后端发送更稳定，也避免要求第三方兼容接口额外支持浏览器 CORS。

## Notes

`Cargo.lock` 变化来自启用 `reqwest` 的 `system-proxy` 特性。这样迁移到后端请求后，仍能沿用 Windows/macOS 系统代理行为，避免网络行为相对 WebView 退化。

图片对话暂未迁移，是为了控制本 PR 范围；图片请求仍保留原实现。

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --no-fail-fast`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `corepack pnpm -C apps/desktop build`
- [x] `corepack pnpm -C apps/desktop lint`
- [x] `cargo run -p pinkbin-scaffold-lint -- scaffolds\conda.toml scaffolds\wechat-pc.toml`
