### PR TITLE
feat(advisor): add Atlas Cloud provider preset

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1254,19 +1254,23 @@ fn open_steam_url(action: String, appid: u64) -> Result<(), String> {
     }
 }
 
-#[tauri::command]
-fn set_advisor(
-    state: State<'_, AppState>,
+fn provider_from_settings(
     provider: String,
     api_key: Option<String>,
     model: String,
     base_url: Option<String>,
-) -> Result<(), String> {
-    let p = match provider.as_str() {
-        "openai" => Provider::OpenAI {
+) -> Result<Provider, String> {
+    Ok(match provider.as_str() {
+        "openai" | "atlas" => Provider::OpenAI {
             api_key: api_key.ok_or_else(|| "api_key required".to_string())?,
             model,
-            base_url: base_url.unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+            base_url: base_url.unwrap_or_else(|| {
+                if provider == "atlas" {
+                    "https://api.atlascloud.ai/v1".to_string()
+                } else {
+                    "https://api.openai.com/v1".to_string()
+                }
+            }),
         },
         "anthropic" => Provider::Anthropic {
             api_key: api_key.ok_or_else(|| "api_key required".to_string())?,
@@ -1284,7 +1288,18 @@ fn set_advisor(
                 .unwrap_or_else(|| "https://generativelanguage.googleapis.com".to_string()),
         },
         other => return Err(format!("unknown provider: {other}")),
-    };
+    })
+}
+
+#[tauri::command]
+fn set_advisor(
+    state: State<'_, AppState>,
+    provider: String,
+    api_key: Option<String>,
+    model: String,
+    base_url: Option<String>,
+) -> Result<(), String> {
+    let p = provider_from_settings(provider, api_key, model, base_url)?;
     *state.advisor.lock().unwrap() = Some(p);
     Ok(())
 }
@@ -1403,6 +1418,30 @@ fn load_all_scaffolds(handle: &AppHandle) -> Vec<Scaffold> {
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn atlas_provider_uses_openai_transport_defaults() {
+        let provider = provider_from_settings(
+            "atlas".to_string(),
+            Some("test-key".to_string()),
+            "deepseek-ai/deepseek-v4-pro".to_string(),
+            None,
+        )
+        .unwrap();
+
+        match provider {
+            Provider::OpenAI {
+                api_key,
+                model,
+                base_url,
+            } => {
+                assert_eq!(api_key, "test-key");
+                assert_eq!(model, "deepseek-ai/deepseek-v4-pro");
+                assert_eq!(base_url, "https://api.atlascloud.ai/v1");
+            }
+            _ => panic!("Atlas Cloud must use the OpenAI-compatible transport"),
+        }
+    }
 
     /// Verifies `pinkbin_walker` skips system trash / volume metadata directories
     /// at directory-read time. Without this prune a scope glob with a leading

--- a/apps/desktop/src/advisorClient.ts
+++ b/apps/desktop/src/advisorClient.ts
@@ -5,7 +5,7 @@
 
 import type { AdvisorRequest, AdvisorResponse } from './types';
 
-export type Provider = 'openai' | 'anthropic' | 'gemini' | 'ollama';
+export type Provider = 'openai' | 'atlas' | 'anthropic' | 'gemini' | 'ollama';
 
 export interface AdvisorSettings {
   provider: Provider;
@@ -27,6 +27,7 @@ const STORAGE_KEY = 'pinkbin.advisor';
 export function detectProvider(baseUrl: string): Provider {
   const u = baseUrl.toLowerCase();
   if (!u) return 'openai';
+  if (u.includes('api.atlascloud.ai')) return 'atlas';
   if (u.includes('11434') || u.includes('/api/chat')) return 'ollama';
   // 识别带 anthropic 字样的代理子域名（如 anthropic.novadiffusion.com），
   // 不仅是官方 anthropic.com。误识别风险极小——OpenAI 协议代理几乎不会
@@ -116,8 +117,11 @@ export async function callAdvisor(
   const userPrompt = JSON.stringify(req, null, 2);
   let raw = '';
 
-  if (settings.provider === 'openai') {
-    const url = (settings.baseUrl || 'https://api.openai.com/v1').replace(/\/$/, '');
+  if (settings.provider === 'openai' || settings.provider === 'atlas') {
+    const defaultUrl = settings.provider === 'atlas'
+      ? 'https://api.atlascloud.ai/v1'
+      : 'https://api.openai.com/v1';
+    const url = (settings.baseUrl || defaultUrl).replace(/\/$/, '');
     const r = await fetch(`${url}/chat/completions`, {
       method: 'POST',
       headers: {
@@ -251,8 +255,11 @@ async function runChatRaw(system: string, user: string, images?: ChatImage[]): P
   const fullUser = user;
   const imgs = images ?? [];
 
-  if (settings.provider === 'openai') {
-    const url = (settings.baseUrl || 'https://api.openai.com/v1').replace(/\/$/, '');
+  if (settings.provider === 'openai' || settings.provider === 'atlas') {
+    const defaultUrl = settings.provider === 'atlas'
+      ? 'https://api.atlascloud.ai/v1'
+      : 'https://api.openai.com/v1';
+    const url = (settings.baseUrl || defaultUrl).replace(/\/$/, '');
     const userContent: unknown = imgs.length === 0
       ? fullUser
       : [

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -87,7 +87,7 @@ export const api = {
     isTauri ? invoke<number>('estimate_size', { path }) : Promise.resolve(0),
 
   setAdvisor: (
-    provider: 'openai' | 'anthropic' | 'gemini' | 'ollama',
+    provider: 'openai' | 'atlas' | 'anthropic' | 'gemini' | 'ollama',
     model: string,
     apiKey?: string,
     baseUrl?: string,

--- a/apps/desktop/src/components/Settings.tsx
+++ b/apps/desktop/src/components/Settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { X, CheckCircle2, Info, Eye, EyeOff, Settings2 } from 'lucide-react';
+import { X, CheckCircle2, Info, Eye, EyeOff, Settings2, Cloud } from 'lucide-react';
 import { api } from '../api';
 import { isTauri } from '../env';
 import {
@@ -14,14 +14,16 @@ type Props = { onClose: () => void };
 
 const PROVIDER_LABEL: Record<Provider, string> = {
   openai: 'OpenAI 兼容',
+  atlas: 'Atlas Cloud',
   anthropic: 'Anthropic',
   gemini: 'Gemini',
   ollama: 'Ollama（本地，免 Key）',
 };
 
-// 手动开关里的选项要短，五个塞在一行；「已识别」标签用完整版说明。
+// 手动开关里的选项要短，六个塞在一行；「已识别」标签用完整版说明。
 const PROVIDER_LABEL_SHORT: Record<Provider, string> = {
   openai: 'OpenAI 兼容',
+  atlas: 'Atlas Cloud',
   anthropic: 'Anthropic',
   gemini: 'Gemini',
   ollama: 'Ollama',
@@ -52,6 +54,14 @@ export function Settings({ onClose }: Props) {
 
   const provider = providerOverride ?? detectProvider(baseUrl);
   const needsKey = provider !== 'ollama';
+
+  const selectProvider = (nextProvider: Provider) => {
+    setProviderOverride(nextProvider);
+    if (nextProvider === 'atlas') {
+      setBaseUrl('https://api.atlascloud.ai/v1');
+      setModel('deepseek-ai/deepseek-v4-pro');
+    }
+  };
 
   const save = async () => {
     setErr(null); setMsg(null);
@@ -91,8 +101,15 @@ export function Settings({ onClose }: Props) {
 
         <p className="hint">
           <Info size={12} />
-          <span>填你服务商给你的 Base URL、API Key 和模型名。OpenAI、DeepSeek、Kimi、各种中转都直接填就能用；本地 Ollama 不用 Key。</span>
+          <span>填你服务商给你的 Base URL、API Key 和模型名。OpenAI、Atlas Cloud、DeepSeek、Kimi、各种中转都直接填就能用；本地 Ollama 不用 Key。</span>
         </p>
+
+        <div className="provider-presets">
+          <button type="button" className="ghost" onClick={() => selectProvider('atlas')}>
+            <Cloud size={13} />
+            Atlas Cloud
+          </button>
+        </div>
 
         <label className="field">
           <span>Base URL</span>
@@ -117,7 +134,7 @@ export function Settings({ onClose }: Props) {
         )}
 
         {baseUrl.trim() && showManual && (
-          <div className="seg seg-5">
+          <div className="seg seg-6">
             <button
               type="button"
               className={`seg-opt${providerOverride === undefined ? ' active' : ''}`}
@@ -130,7 +147,7 @@ export function Settings({ onClose }: Props) {
                 key={p}
                 type="button"
                 className={`seg-opt${providerOverride === p ? ' active' : ''}`}
-                onClick={() => setProviderOverride(p)}
+                onClick={() => selectProvider(p)}
               >
                 {PROVIDER_LABEL_SHORT[p]}
               </button>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -833,6 +833,20 @@ footer {
 .seg-opt.active { background: var(--pink); color: var(--ink); }
 .seg-5 { grid-template-columns: repeat(5, 1fr); }
 .seg-5 .seg-opt { padding: 8px 4px; font-size: 10.5px; text-align: center; }
+.seg-6 { grid-template-columns: repeat(6, 1fr); }
+.seg-6 .seg-opt { padding: 8px 4px; font-size: 10px; text-align: center; }
+
+.provider-presets {
+  display: flex;
+  min-height: 30px;
+}
+.provider-presets .ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 9px;
+  font-size: 11px;
+}
 
 /* Base URL 下方的协议识别标签 + 手动开关入口 */
 .provider-detect {
@@ -2631,4 +2645,3 @@ footer {
   from { background-position: 0% 0%; }
   to   { background-position: -200% 0%; }
 }
-


### PR DESCRIPTION
## Summary

- Add Atlas Cloud as a first-class AI advisor provider while reusing Pinkbin's existing OpenAI-compatible transport in browser and Tauri modes.
- Auto-detect `api.atlascloud.ai` and provide a one-click preset for `https://api.atlascloud.ai/v1` with `deepseek-ai/deepseek-v4-pro`.
- Keep API keys local and preserve custom endpoint and model overrides.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] New scaffold (please fill the section below)
- [ ] Refactor / chore

## New scaffold checklist

新增/重写 scaffold 请按 14-phase 工作流（见 [`.claude/commands/add-scaffold.md`](../.claude/commands/add-scaffold.md)）走全流程，逐项确认：

- [ ] **Phase 0**: 已读 `crates/scaffold/src/lib.rs`、`apps/desktop/src/components/Studio.tsx`、`types.ts`，UI 边界已确认
- [ ] **Phase 1-2**: `docs/scaffold-requirements/<category>.md` 含本 app 的范围 / L1-L2-L3 分级 / 红线
- [ ] **Phase 5-7**: 文档里有 "实测路径映射" 节（与 TOML glob 一致）
- [ ] **Phase 8**: `id` kebab-case 唯一；`risk` 诚实；`disclaimer` 显式列红线
- [ ] **Phase 9**: `cargo run -p pinkbin-scaffold-lint -- scaffolds/<id>.toml` 通过
- [ ] **Phase 10**: `crates/scaffold/tests/<id>_safety.rs` 存在；`cargo test -p pinkbin-scaffold` 通过；含**红线断言**
- [ ] **Phase 11**: 若改了 `Scaffold`/`Scope` 等结构，`cargo check -p pinkbin-desktop` + `pnpm -C apps/desktop exec tsc --noEmit` 都干净
- [ ] **Phase 12-13**: 若改 UI，套了 `<ErrorBoundary>`、用两步确认（不用 `window.confirm`）；`pnpm tauri dev` 实机跑过
- [ ] **Phase 14**: `docs/scaffold-requirements/STATUS.md` 已更新

## Test plan

- [x] `cargo test --workspace` (37 passed)
- [ ] `pnpm tauri dev` smoke-tested locally
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] TypeScript project build and Vite production build
- [x] Browser preview at desktop and 390px mobile widths
- [x] Live Atlas Cloud structured advisor request using the new `atlas` route

`pnpm lint` did not reach ESLint because the current ESLint 9 setup has no `eslint.config.*`; TypeScript compilation completed successfully.
